### PR TITLE
Fix #184: Hide recently reviewed section during search and reposition…

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,14 @@
         <button class="theme-toggle" id="themeToggle">🌙 Dark</button>
       </nav>
       <p>Welcome! Explore amazing CSS artworks created by contributors.</p>
-      <!-- Sorting Dropdown -->
+      
+    </header>
+    <section class="recently-reviewed-container">
+      <h2 class="section-title">Recently Reviewed</h2>
+      <div class="gallery" id="recently-reviewed-gallery">
+      </div>
+    </section>
+    <!-- Sorting Dropdown -->
       <div class="sorting-container">
         <label for="sorting-dropdown">Sort by:</label>
         <select id="sorting-dropdown">
@@ -58,12 +65,6 @@
           <option value="least-liked">Least Liked</option>
         </select>
       </div>
-    </header>
-    <section class="recently-reviewed-container">
-      <h2 class="section-title">Recently Reviewed</h2>
-      <div class="gallery" id="recently-reviewed-gallery">
-      </div>
-    </section>
     <h2 class="section-title">Art Museum</h2>
     <main class="gallery" id="gallery-container"></main>
 

--- a/js/script.js
+++ b/js/script.js
@@ -265,17 +265,31 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  // --- Search Filter ---
-  searchBar.addEventListener("input", () => {
-    const query = searchBar.value.toLowerCase().trim();
-    const filteredArts = allArts.filter(
-      (art) =>
-        art.title.toLowerCase().includes(query) ||
-        art.author.toLowerCase().includes(query)
-    );
-    renderArts(filteredArts);
-  });
+  // --- Search Filter with Recently Reviewed Hide/Show (Fix for Issue #184) ---
+const recentlyReviewedSection = document.querySelector('.recently-reviewed-container');
 
+searchBar.addEventListener("input", () => {
+  const query = searchBar.value.toLowerCase().trim();
+  
+  // Hide or show recently reviewed section based on search query
+  if (recentlyReviewedSection) {
+    if (query.length > 0) {
+      // Hide recently reviewed when searching
+      recentlyReviewedSection.classList.add('hidden');
+    } else {
+      // Show recently reviewed when search is empty
+      recentlyReviewedSection.classList.remove('hidden');
+    }
+  }
+  
+  // Existing filter logic
+  const filteredArts = allArts.filter(
+    (art) =>
+      art.title.toLowerCase().includes(query) ||
+      art.author.toLowerCase().includes(query)
+  );
+  renderArts(filteredArts);
+});
   // --- Theme toggle and other existing functions ---
   const toggleBtn = document.getElementById("themeToggle");
   const body = document.body;

--- a/style.css
+++ b/style.css
@@ -1051,3 +1051,33 @@ header p {
   grid-template-columns: repeat(3, 320px); 
   max-width: calc(320px * 3 + 30px * 2); 
 }
+
+/* Fix for Issue #184: Recently Reviewed Section Transitions */
+
+/* Add smooth transition for recently reviewed container */
+.recently-reviewed-container {
+  transition: opacity 0.3s ease, max-height 0.3s ease, margin 0.3s ease;
+  overflow: hidden;
+  opacity: 1;
+  max-height: 1000px; /* Adjust based on your content */
+}
+
+/* Hidden state for recently reviewed section */
+.recently-reviewed-container.hidden {
+  opacity: 0;
+  max-height: 0;
+  margin: 0;
+  pointer-events: none;
+}
+
+/* Ensure sorting container has proper spacing */
+.sorting-container {
+  margin-top: 20px;
+  margin-bottom: 30px;
+  transition: margin 0.3s ease;
+}
+
+/* Adjust margin when recently reviewed is hidden */
+.recently-reviewed-container.hidden + .sorting-container {
+  margin-top: 0;
+}


### PR DESCRIPTION
**Fixes #184**

### Summary of Changes

This PR addresses the user experience issue where the "Recently Reviewed" section blocked search results and repositions the "Sort by Likes" button for better flow.

* Hides the "Recently Reviewed" section when a search query is active.
* Moves the "Sort by Likes" button to appear after the "Recently Reviewed" section.

---

### Before & After Screenshots

* **Before:**<img width="1881" height="913" alt="image" src="https://github.com/user-attachments/assets/c99a7db4-274d-42d8-9331-898049226664" />
* **After:** <img width="1874" height="886" alt="image" src="https://github.com/user-attachments/assets/fe2ba0af-173c-4caf-9a33-4baa5f11a068" />
* 
<img width="1822" height="793" alt="image" src="https://github.com/user-attachments/assets/7dd66d93-0230-4879-81ce-0f95b985f8be" />
