### PR TITLE
Fix: Sort by likes now works on filtered search results

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -5,8 +5,9 @@ document.addEventListener("DOMContentLoaded", () => {
   // Sorting dropdown
   const sortingDropdown = document.getElementById("sorting-dropdown");
   let allArts = []; // This will store the merged data (art info + likes)
+  let currentFilteredArts = [];  //Initialize currentFilteredArts with all arts
   let pagination = null; // Pagination instance
-
+  
   const RecentlyReviewed = {
     get: () => {
       try {
@@ -149,6 +150,9 @@ document.addEventListener("DOMContentLoaded", () => {
         likes: artLikesMap.get(art.file) || 0, // Add likes property, default to 0
       }));
 
+      // Initialize currentFilteredArts with all arts
+      currentFilteredArts = [...allArts];
+
       // Initialize pagination after data is loaded
       initializePagination();
       renderArts(allArts);
@@ -243,6 +247,9 @@ document.addEventListener("DOMContentLoaded", () => {
    * Wrapper function to maintain compatibility with existing code
    */
   function renderArts(arts) {
+
+    // Update currentFilteredArts whenever renderArts is called
+    currentFilteredArts = arts;
     if (pagination) {
       pagination.setFilteredItems(arts);
       pagination.render();
@@ -253,9 +260,10 @@ document.addEventListener("DOMContentLoaded", () => {
     
 
   // --- Sorting integration ---
+  // FIXED: Now sorts currentFilteredArts instead of allArts
   window.sortAndRenderArts = function() {
-    if (!allArts) return;
-    const sorted = window.sortArts ? window.sortArts(allArts) : allArts;
+    if (!currentFilteredArts || currentFilteredArts.length === 0) return;
+    const sorted = window.sortArts ? window.sortArts(currentFilteredArts) : currentFilteredArts;
     renderArts(sorted);
   };
 


### PR DESCRIPTION
 ##  Issue
Fixes #185 

##  Description
This PR fixes the sorting functionality where clicking "Sort by Likes" after searching would incorrectly display all artworks instead of sorting only the filtered search results.

## Implementation Details
- Added `currentFilteredArts` variable to track currently displayed artworks
- Modified `sortAndRenderArts()` function to sort filtered results instead of all artworks
- Updated `renderArts()` function to keep the filtered state synchronized

## Testing
- [x] Search + Sort works correctly (only sorts search results)
- [x] Sort without search works (sorts all artworks)
- [x] Tested in Chrome and Firefox
- [x] No console errors

## Screenshots

### Before Fix
<img width="1880" height="911" alt="image" src="https://github.com/user-attachments/assets/23073618-7aab-4cd2-885e-36a9b90c6066" />

### After Fix  
<img width="1858" height="917" alt="image" src="https://github.com/user-attachments/assets/c7649958-08d9-44b1-bb7d-c36d1a625b83" />